### PR TITLE
Minor changes to arxiv & dubcore parsers for compatibility with Direct Ingest

### DIFF
--- a/pyingest/parsers/arxiv.py
+++ b/pyingest/parsers/arxiv.py
@@ -95,12 +95,20 @@ class ArxivParser(DublinCoreParser):
 
         if r['properties']:
             prop = {}
+            pubnote_prop = []
             for x in r['properties']:
                 if 'http://arxiv.org' in x:
                     prop['HTML'] = x
-                if 'doi:' in x:
-                    prop['DOI'] = x
+                else:
+                    if 'doi:' in x:
+                        prop['DOI'] = x
+                    pubnote_prop.append(x)
             r['properties'] = prop
+
+            if r['comments']:
+                if len(pubnote_prop) > 0:
+                    r['comments'] = r['comments'] + pubnote_prop
+                    r['comments'] = "; ".join(r['comments'])
 
         return r
 #

--- a/pyingest/parsers/arxiv.py
+++ b/pyingest/parsers/arxiv.py
@@ -108,7 +108,6 @@ class ArxivParser(DublinCoreParser):
             if r['comments']:
                 if len(pubnote_prop) > 0:
                     r['comments'] = r['comments'] + pubnote_prop
-                    r['comments'] = "; ".join(r['comments'])
 
         return r
 #

--- a/pyingest/parsers/arxiv.py
+++ b/pyingest/parsers/arxiv.py
@@ -49,11 +49,14 @@ class ArxivParser(DublinCoreParser):
             pass
 
         if r['abstract']:
+            r['comments']=[x.replace('Comment:','').strip() for x in r['abstract'][1:]]
             r['abstract']=r['abstract'][0]
 
         if r['bibcode']:
             idarray = r['bibcode'].split(':')
             arxiv_id = idarray[-1]
+
+            r['publication'] = 'eprint arXiv:'+arxiv_id
 
             if arxiv_id[0].isalpha():
                 arx_field = arxiv_id.split('/')[0].replace('-','.')

--- a/pyingest/parsers/dubcore.py
+++ b/pyingest/parsers/dubcore.py
@@ -92,7 +92,7 @@ class DublinCoreParser(BaseXmlToDictParser):
 # Pubdate
 
             if self.get_tag(r,'dc:date'):
-                output_metadata['pubdate'] = self.get_tag(r,'dc:date')[-1]
+                output_metadata['pubdate'] = self.get_tag(r,'dc:date')[0]
 
             
 # Abstract

--- a/pyingest/serializers/classic.py
+++ b/pyingest/serializers/classic.py
@@ -36,7 +36,7 @@ class Tagged(object):
                              ('affiliations', { 'tag': 'F', 'join': ', ', 'fmt': format_affids }),
                              ('pubdate',      { 'tag': 'D', 'fmt': format_pubdate }),
                              ('publication',  { 'tag': 'J' }),
-                             ('comments',     { 'tag': 'X' }),
+                             ('comments',     { 'tag': 'X', 'join': '; ' }),
                              ('source',       { 'tag': 'G'  }),
                              ('keywords',     { 'tag': 'K', 'join': ', ' }),
                              ('database',     { 'tag': 'W', 'join': '; ' }),

--- a/pyingest/serializers/classic.py
+++ b/pyingest/serializers/classic.py
@@ -36,6 +36,7 @@ class Tagged(object):
                              ('affiliations', { 'tag': 'F', 'join': ', ', 'fmt': format_affids }),
                              ('pubdate',      { 'tag': 'D', 'fmt': format_pubdate }),
                              ('publication',  { 'tag': 'J' }),
+                             ('comments',     { 'tag': 'X' }),
                              ('source',       { 'tag': 'G'  }),
                              ('keywords',     { 'tag': 'K', 'join': ', ' }),
                              ('database',     { 'tag': 'W', 'join': '; ' }),

--- a/test_aps_parser.py
+++ b/test_aps_parser.py
@@ -1,6 +1,7 @@
 import glob
 import cStringIO
 import pyingest.parsers.aps as aps
+import pyingest.parsers.arxiv as arxiv
 import pyingest.serializers.classic
 import traceback
 import json
@@ -29,23 +30,39 @@ testfile = ['test_data/stubdata/input/apsjats_10.1103.PhysRevA.95.129999.fulltex
 #     
 #testfile = [testfile[1]]
 
+#for f in testfile:
+#    try:
+#        with open(f,'rU') as fp:
+#            parser = aps.APSJATSParser()
+#            document = parser.parse(fp)
+#            print(document)
+##           for k in document.keys():
+##               print k,type(document[k])
+#
+#            serializer = pyingest.serializers.classic.Tagged()
+#            outputfp = open('aps.tag','a')
+#            serializer.write(document,outputfp)
+#            outputfp.close()
+#    except: 
+#        print "ERROR!\n%s\n"%f
+#        traceback.print_exc()
+#        pass
+#    else:
+#        pass
+#        print "OK:",f
+
+
+testfile = glob.glob('test_data/arxiv.test/oai*')
 for f in testfile:
     try:
         with open(f,'rU') as fp:
-            parser = aps.APSJATSParser()
+            parser = arxiv.ArxivParser()
             document = parser.parse(fp)
-            print(document)
-#           for k in document.keys():
-#               print k,type(document[k])
-
             serializer = pyingest.serializers.classic.Tagged()
-            outputfp = open('aps.tag','a')
+            outputfp = open('arxiv.tag','a')
             serializer.write(document,outputfp)
             outputfp.close()
-    except: 
+    except:
         print "ERROR!\n%s\n"%f
         traceback.print_exc()
         pass
-    else:
-        pass
-        print "OK:",f

--- a/test_data/arxiv.test/tagged/oai_ArXiv.org_0901_2443.tagged
+++ b/test_data/arxiv.test/tagged/oai_ArXiv.org_0901_2443.tagged
@@ -3,6 +3,8 @@
   tin isotopes
 %A &Ouml;zel, B.; Enders, J.; Lenske, H.; von Neumann-Cosel, P.; Poltoratska, I.; Ponomarev, V. Yu.; Richter, A.; Savran, D.; Tsoneva, N.
 %D 2009/01
+%J eprint arXiv:0901.2443
+%X submitted to Phys. Lett. B
 %K Nuclear Experiment
 %B The $^{112,120}$Sn$(\gamma,\gamma')$ reactions have been studied at the
 S-DALINAC. Electric dipole (E1) strength distributions have been determined

--- a/test_data/arxiv.test/tagged/oai_ArXiv.org_1711_04702.tagged
+++ b/test_data/arxiv.test/tagged/oai_ArXiv.org_1711_04702.tagged
@@ -3,6 +3,8 @@
   consensus networks with an integrated visualization tool
 %A Gysi, Deisy Morselli; Voigt, Andre; Fragoso, Tiago de Miranda; Almaas, Eivind; Nowick, Katja
 %D 2017/11
+%J eprint arXiv:1711.04702
+%X 13 pages, 3 Figures
 %K Quantitative Biology - Molecular Networks
 %B Background: Gene co-expression network analyses have become a central
 approach for the systems-level analysis of biological data. Several software

--- a/test_data/arxiv.test/tagged/oai_ArXiv.org_1711_05739.tagged
+++ b/test_data/arxiv.test/tagged/oai_ArXiv.org_1711_05739.tagged
@@ -2,6 +2,9 @@
 %T Planet-Planet Occultations in TRAPPIST-1 and Other Exoplanet Systems
 %A Luger, Rodrigo; Lustig-Yaeger, Jacob; Agol, Eric
 %D 2017/11
+%J eprint arXiv:1711.05739
+%X 36 pages, 25 figures. Accepted to ApJ. Multi-purpose photodynamical
+  code available at github.com/rodluger/planetplanet
 %K Astrophysics - Earth and Planetary Astrophysics
 %B We explore the occurrence and detectability of planet-planet occultations
 (PPOs) in exoplanet systems. These are events during which a planet occults the

--- a/test_data/arxiv.test/tagged/oai_ArXiv.org_astro-ph_9501013.tagged
+++ b/test_data/arxiv.test/tagged/oai_ArXiv.org_astro-ph_9501013.tagged
@@ -2,7 +2,7 @@
 %T Cosmological parameters and the redshift distribution of gravitational
   lenses
 %A Helbig, Phillip; Kayser, Rainer
-%D 1995/09
+%D 1995/01
 %J eprint arXiv:astro-ph/9501013
 %X One self-unpacking uuencoded compressed PostScript file (created with
   uufiles) containing the complete text with all figures included (here 140kb
@@ -10,7 +10,7 @@
   US-size paper. Paper version available on request. Changes--nothing removed,
   typos corrected, the following additions: one figure, one table and some text
   explaining the structure in the plots in more detail; more detailed
-  explanation of the statistics used. Accepted by Astronomy and Astrophysics
+  explanation of the statistics used. Accepted by Astronomy and Astrophysics; Astron.Astrophys.308:359,1996
 %K Astrophysics
 %B For known gravitational lens systems the redshift distribution of the lenses
 is compared with theoretical expectations for $10^{4}$~Friedmann-Lema\^\i

--- a/test_data/arxiv.test/tagged/oai_ArXiv.org_astro-ph_9501013.tagged
+++ b/test_data/arxiv.test/tagged/oai_ArXiv.org_astro-ph_9501013.tagged
@@ -3,6 +3,14 @@
   lenses
 %A Helbig, Phillip; Kayser, Rainer
 %D 1995/09
+%J eprint arXiv:astro-ph/9501013
+%X One self-unpacking uuencoded compressed PostScript file (created with
+  uufiles) containing the complete text with all figures included (here 140kb
+  gzipped, unpacked 975kb). 10 pages. Should be printable without loss on
+  US-size paper. Paper version available on request. Changes--nothing removed,
+  typos corrected, the following additions: one figure, one table and some text
+  explaining the structure in the plots in more detail; more detailed
+  explanation of the statistics used. Accepted by Astronomy and Astrophysics
 %K Astrophysics
 %B For known gravitational lens systems the redshift distribution of the lenses
 is compared with theoretical expectations for $10^{4}$~Friedmann-Lema\^\i

--- a/test_data/arxiv.test/tagged/oai_ArXiv.org_cond-mat_9706061.tagged
+++ b/test_data/arxiv.test/tagged/oai_ArXiv.org_cond-mat_9706061.tagged
@@ -3,6 +3,8 @@
   invariance
 %A Alekseev, Anton Yu.; Cheianov, Vadim V.; Froehlich, Jurg
 %D 1997/06
+%J eprint arXiv:cond-mat/9706061
+%X 4pages, LaTeX
 %K Condensed Matter - Mesoscopic Systems and Quantum Hall Effect; High Energy Physics - Theory
 %B In this letter we address the question how interactions affect the DC
 conductance of a one-dimensional electron system not necessarily adequately

--- a/test_data/arxiv.test/tagged/oai_ArXiv.org_hep-th_0408048.tagged
+++ b/test_data/arxiv.test/tagged/oai_ArXiv.org_hep-th_0408048.tagged
@@ -1,9 +1,9 @@
 %R 2004hep.th....8048S
 %T An invitation to loop quantum gravity
 %A Smolin, Lee
-%D 2005/06
+%D 2004/08
 %J eprint arXiv:hep-th/0408048
-%X 50 pages, to be submitted to Reviews of Modern Physics
+%X 50 pages, to be submitted to Reviews of Modern Physics; doi:10.1142/9789812702340_0078
 %K High Energy Physics - Theory
 %B We describe the basic assumptions and key results of loop quantum gravity,
 which is a background independent approach to quantum gravity. The emphasis is

--- a/test_data/arxiv.test/tagged/oai_ArXiv.org_hep-th_0408048.tagged
+++ b/test_data/arxiv.test/tagged/oai_ArXiv.org_hep-th_0408048.tagged
@@ -2,6 +2,8 @@
 %T An invitation to loop quantum gravity
 %A Smolin, Lee
 %D 2005/06
+%J eprint arXiv:hep-th/0408048
+%X 50 pages, to be submitted to Reviews of Modern Physics
 %K High Energy Physics - Theory
 %B We describe the basic assumptions and key results of loop quantum gravity,
 which is a background independent approach to quantum gravity. The emphasis is

--- a/test_data/arxiv.test/tagged/oai_ArXiv.org_math_0306266.tagged
+++ b/test_data/arxiv.test/tagged/oai_ArXiv.org_math_0306266.tagged
@@ -2,6 +2,7 @@
 %T The Lovasz number of random graphs
 %A Coja-Oghlan, Amin
 %D 2003/06
+%J eprint arXiv:math/0306266
 %K Mathematics - Combinatorics; 05C80, 05C15
 %B We study the Lovasz number theta along with two further SDP relaxations
 theta1, theta1/2 of the independence number and the corresponding relaxations


### PR DESCRIPTION
These changes improve the match between arxiv records currently in Solr and the output of ADSImportPipeline:direct.  Also included are slight modifications to the classic serializer from last time: the list elements of the comments tag weren't being handled correctly.  All changes reflected in test output, and all tests pass.