### PR TITLE
Improve setup, support datacite 4 and include other fields

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+
+[run]
+source = pyingest
+omit = pyingest/tests*

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ docs/_build/
 
 # PyBuilder
 target/
+python/

--- a/pyingest/parsers/datacite.py
+++ b/pyingest/parsers/datacite.py
@@ -38,6 +38,23 @@ class DataCiteParser(BaseXmlToDictParser):
                 abstract = self._text(s)
         return abstract
 
+    def get_described_by(self, r):
+        """
+        Record that describes the current record.
+            Page 52: https://schema.datacite.org/meta/kernel-4.1/doc/DataCite-MetadataKernel_v4.1.pdf
+        """
+        relation_type = 'IsDescribedBy'
+        return self._get_related_identifiers(r, relation_type)
+
+    def get_description_of(self, r):
+        """
+        Current record is a description of a given record.
+            Page 52: https://schema.datacite.org/meta/kernel-4.1/doc/DataCite-MetadataKernel_v4.1.pdf
+        """
+        relation_type = 'Describes'
+        return self._get_related_identifiers(r, relation_type)
+
+
     def get_versions(self, r):
         """
         It relates an unversioned code repository to one of its specific software versions.
@@ -70,6 +87,10 @@ class DataCiteParser(BaseXmlToDictParser):
         relation_type = 'IsSourceOf'
         return self._get_related_identifiers(r, relation_type)
 
+    def get_citations(self, r):
+        relation_type = 'IsCitedBy'
+        return self._get_related_identifiers(r, relation_type)
+
     def get_references(self, r):
         relation_type = 'Cites'
         return self._get_related_identifiers(r, relation_type)
@@ -84,22 +105,26 @@ class DataCiteParser(BaseXmlToDictParser):
         return related_identifiers
 
     def get_doctype(self, r):
+        """
+        Resource type
+            Page 43: https://schema.datacite.org/meta/kernel-4.1/doc/DataCite-MetadataKernel_v4.1.pdf
+        """
         datacite_resourcetype_mapping = {
-            'audiovisual': 'misc',
-            'collection': 'misc',
-            'datapaper': 'misc',
-            'dataset': 'misc',
-            'event': 'misc',
-            'image': 'misc',
-            'interactiveresource': 'misc',
-            'model': 'misc',
-            'physicalobject': 'misc',
-            'service': 'misc',
-            'software': 'software',
-            'sound': 'misc',
-            'text': 'misc',
-            'workflow': 'misc',
-            'other': 'misc',
+            'Audiovisual': 'misc',
+            'Collection': 'misc',
+            'DataPaper': 'misc',
+            'Dataset': 'misc',
+            'Event': 'misc',
+            'Image': 'misc',
+            'InteractiveResource': 'misc',
+            'Model': 'misc',
+            'PhysicalObject': 'misc',
+            'Service': 'misc',
+            'Software': 'software',
+            'Sound': 'misc',
+            'Text': 'misc',
+            'Workflow': 'misc',
+            'Other': 'misc',
         }
         return datacite_resourcetype_mapping.get(r.get('resourceType', {}).get('@resourceTypeGeneral', None), "misc")
 
@@ -255,12 +280,15 @@ class DataCiteParser(BaseXmlToDictParser):
             'keywords': keywords,
             'abstract': self.get_abstract(r),
             'references': self.get_references(r),
+            'citations': self.get_citations(r),
             'doctype': self.get_doctype(r),
             'version': version,
             'versions': self.get_versions(r),
             'version_of': self.get_version_of(r),
             'forked_from': self.get_forked_from(r),
             'forks': self.get_forks(r),
+            'described_by': self.get_described_by(r),
+            'description_of': self.get_description_of(r),
             'source': pub
             }
 

--- a/pyingest/parsers/datacite.py
+++ b/pyingest/parsers/datacite.py
@@ -39,15 +39,12 @@ class DataCiteParser(BaseXmlToDictParser):
         return abstract
 
     def get_references(self, r):
-        # as of version 3.1 of datacite schema, "References" is not an
-        # allowed description type but here we try just for kicks
         references = []
-        for s in self._array(self._dict(r.get('descriptions')).get('description',[])):
-            t = s.get('@descriptionType')
+        for s in self._array(self._dict(r.get('relatedIdentifiers')).get('relatedIdentifier',[])):
+            t = s.get('@relationType')
             c = self._text(s)
-            if t == 'References':
-                # XXX not supported yet, but one can only hope...
-                references = c.split('\n')
+            if t == 'Cites':
+                references.append(c)
         return references
 
     def get_doctype(self, r):

--- a/pyingest/parsers/datacite.py
+++ b/pyingest/parsers/datacite.py
@@ -38,14 +38,50 @@ class DataCiteParser(BaseXmlToDictParser):
                 abstract = self._text(s)
         return abstract
 
+    def get_versions(self, r):
+        """
+        It relates an unversioned code repository to one of its specific software versions.
+            Page 71: https://schema.datacite.org/meta/kernel-4.1/doc/DataCite-MetadataKernel_v4.1.pdf
+        """
+        relation_type = 'HasVersion'
+        return self._get_related_identifiers(r, relation_type)
+
+    def get_version_of(self, r):
+        """
+        It relates a specific version of a software package to its software code repository.
+            Page 71: https://schema.datacite.org/meta/kernel-4.1/doc/DataCite-MetadataKernel_v4.1.pdf
+        """
+        relation_type = 'IsVersionOf'
+        return self._get_related_identifiers(r, relation_type)
+
+    def get_forked_from(self, r):
+        """
+        It denotes software that is a fork of other software
+            Page 71: https://schema.datacite.org/meta/kernel-4.1/doc/DataCite-MetadataKernel_v4.1.pdf
+        """
+        relation_type = 'IsDerivedFrom'
+        return self._get_related_identifiers(r, relation_type)
+
+    def get_forks(self, r):
+        """
+        It denotes software that is the origin of a fork
+            Page 71: https://schema.datacite.org/meta/kernel-4.1/doc/DataCite-MetadataKernel_v4.1.pdf
+        """
+        relation_type = 'IsSourceOf'
+        return self._get_related_identifiers(r, relation_type)
+
     def get_references(self, r):
-        references = []
+        relation_type = 'Cites'
+        return self._get_related_identifiers(r, relation_type)
+
+    def _get_related_identifiers(self, r, relation_type):
+        related_identifiers = []
         for s in self._array(self._dict(r.get('relatedIdentifiers')).get('relatedIdentifier',[])):
             t = s.get('@relationType')
             c = self._text(s)
-            if t == 'Cites':
-                references.append(c)
-        return references
+            if t == relation_type:
+                related_identifiers.append(c)
+        return related_identifiers
 
     def get_doctype(self, r):
         datacite_resourcetype_mapping = {
@@ -221,8 +257,13 @@ class DataCiteParser(BaseXmlToDictParser):
             'references': self.get_references(r),
             'doctype': self.get_doctype(r),
             'version': version,
+            'versions': self.get_versions(r),
+            'version_of': self.get_version_of(r),
+            'forked_from': self.get_forked_from(r),
+            'forks': self.get_forks(r),
             'source': pub
             }
+
 #
 #
 #if __name__ == "__main__":

--- a/pyingest/parsers/datacite3.py
+++ b/pyingest/parsers/datacite3.py
@@ -20,7 +20,7 @@ class DataCite3Parser(BaseXmlToDictParser):
 
     def __init__(self):
         # make sure we are utf-8 clean on stdout, stderr
-        self.DC3_SCHEMA = 'http://datacite.org/schema/kernel-3'
+        self.DC3_SCHEMAS = ['http://datacite.org/schema/kernel-3', 'http://datacite.org/schema/kernel-4']
         self.OA_URIS = [ 'info:eu-repo/semantics/openAccess' ]
         self.OA_TEXT = [ 'Open Access' ]
 
@@ -65,9 +65,9 @@ class DataCite3Parser(BaseXmlToDictParser):
 
         # check for namespace to make sure it's datacite3
         schema = r.get('@xmlns')
-        if schema != self.DC3_SCHEMA:
+        if schema not in self.DC3_SCHEMAS:
             raise WrongSchemaException("Unexpected XML schema \"%s\"" % schema)
-    
+
         if 'DOI' != r.get('identifier',{}).get('@identifierType',''):
             raise MissingDoiException("//identifier['@identifierType'] not DOI!")
         doi = r.get('identifier').get('#text')
@@ -133,7 +133,7 @@ class DataCite3Parser(BaseXmlToDictParser):
             caffils.append(aff.strip())
 
         # for now we are ignoring <dates> until it's clear what goes in there...
-    
+
         # we should probably look at what's in '@resourceTypeGeneral'...
         rtype = self._text(r.get('resourceType'))
 
@@ -184,7 +184,7 @@ class DataCite3Parser(BaseXmlToDictParser):
         if doi:
             properties['DOI'] = doi
 
-        return { 
+        return {
             'bibcode': bibcode or '',
             'authors': authors,
             'affiliations': aaffils,
@@ -198,9 +198,9 @@ class DataCite3Parser(BaseXmlToDictParser):
             'source': pub
             }
 #
-#    
+#
 #if __name__ == "__main__":
-#    
+#
 #    # allows program to print utf-8 encoded output sensibly
 #    sys.stdout = codecs.getwriter('utf-8')(sys.stdout)
 #    sys.stderr = codecs.getwriter('utf-8')(sys.stderr)

--- a/pyingest/parsers/zenodo.py
+++ b/pyingest/parsers/zenodo.py
@@ -6,13 +6,13 @@ import sys
 import json
 import re
 import logging
-from datacite3 import DataCite3Parser
+from datacite import DataCiteParser
 
 
 class WrongPublisherException(Exception):
     pass
 
-class ZenodoParser(DataCite3Parser):
+class ZenodoParser(DataCiteParser):
 
     def get_references(self, r):
         # as of version 3.1 of datacite schema, "References" is not an
@@ -55,9 +55,9 @@ class ZenodoParser(DataCite3Parser):
 
         return doc
 #
-#    
+#
 #if __name__ == "__main__":
-#    
+#
 #    # allows program to print utf-8 encoded output sensibly
 #    import codecs
 #    sys.stdout = codecs.getwriter('utf-8')(sys.stdout)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,9 @@
-.
+adsputils==1.0.7
+bs4==0.0.1
+lxml==4.2.1
+functools32==3.2.3.post2
+jsonschema==2.6.0
+namedentities==1.9.4
+python-dateutil==2.6.0
+six==1.11.0
+xmltodict==0.11.0

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,41 @@
-from setuptools import setup
 import os
+from subprocess import Popen, PIPE
 
-# no github commands in install requires, will require an official release.
-os.system('pip install --upgrade git+https://github.com/adsabs/ADSPipelineUtils.git')
+try:
+    from setuptools import setup, find_packages
+except ImportError:
+    from distutils.core import setup, find_packages
+
+try:
+    import pypandoc
+    long_description = pypandoc.convert('README.md', 'rst')
+except (IOError, ImportError):
+    long_description = ""
+
+with open('requirements.txt') as f:
+    required = f.read().splitlines()
+
+def get_git_version(default="v0.0.1"):
+    try:
+        p = Popen(['git', 'describe', '--tags'], stdout=PIPE, stderr=PIPE)
+        p.stderr.close()
+        line = p.stdout.readlines()[0]
+        line = line.strip()
+        return line
+    except:
+        return default
 
 setup(
     name='pyingest',
-    version='0.5.0',
-    packages=['pyingest','pyingest.config','pyingest.extractors','pyingest.parsers','pyingest.serializers','pyingest.validators','pyingest.extractors.grobid'],
-    install_requires=['bs4<=0.0.1', 'lxml<=4.2.1', 'functools32<=3.2.3.post2', 'jsonschema<=2.6.0', 'namedentities<=1.9.4', 'python-dateutil<=2.6.0', 'six<=1.11.0', 'xmltodict<=0.11.0']
-)
+    version=get_git_version(default="v0.0.1"),
+    url='https://github.com/adsabs/adsabs-pyingest',
+    license='MIT',
+    author="NASA/SAO ADS",
+    description='ADS collection or python parsers, validators, and serializers for adsabs ingest pipeline',
+    long_description=long_description,
+    packages=find_packages(),
+    include_package_data=True,
+    zip_safe=False,
+    platforms='any',
+    install_requires=required,
+  )

--- a/test_data/stubdata/input/datacite-example-full-v3.1.xml
+++ b/test_data/stubdata/input/datacite-example-full-v3.1.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xsi:schemaLocation="http://datacite.org/schema/kernel-3 http://schema.datacite.org/meta/kernel-3/metadata.xsd" xmlns="http://datacite.org/schema/kernel-3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <identifier identifierType="DOI">10.5072/example-full</identifier>
+    <creators>
+        <creator>
+            <creatorName>Miller, Elizabeth</creatorName>
+            <nameIdentifier schemeURI="http://orcid.org/" nameIdentifierScheme="ORCID">0000-0001-5000-0007</nameIdentifier>
+            <affiliation>DataCite</affiliation>
+        </creator>
+    </creators>
+    <titles>
+        <title xml:lang="en-us">Full DataCite XML Example</title>
+        <title xml:lang="en-us" titleType="Subtitle">Demonstration of DataCite Properties.</title>
+    </titles>
+    <publisher>DataCite</publisher>
+    <publicationYear>2014</publicationYear>
+    <subjects>
+        <subject xml:lang="en-us" schemeURI="http://dewey.info/" subjectScheme="dewey">000 computer science</subject>
+    </subjects>
+    <contributors>
+        <contributor contributorType="ProjectLeader">
+            <contributorName>Starr, Joan</contributorName>
+            <nameIdentifier schemeURI="http://orcid.org/" nameIdentifierScheme="ORCID">0000-0002-7285-027X</nameIdentifier>
+            <affiliation>California Digital Library</affiliation>
+        </contributor>
+    </contributors>
+    <dates>
+        <date dateType="Updated">2014-10-17</date>
+    </dates>
+    <language>en-us</language>
+    <resourceType resourceTypeGeneral="Software">XML</resourceType>
+    <alternateIdentifiers>
+        <alternateIdentifier alternateIdentifierType="URL">http://schema.datacite.org/schema/meta/kernel-3.1/example/datacite-example-full-v3.1.xml</alternateIdentifier>
+    </alternateIdentifiers>
+    <relatedIdentifiers>
+        <relatedIdentifier relatedIdentifierType="URL" relationType="HasMetadata" relatedMetadataScheme="citeproc+json" schemeURI="https://github.com/citation-style-language/schema/raw/master/csl-data.json">http://data.datacite.org/application/citeproc+json/10.5072/example-full</relatedIdentifier>
+        <relatedIdentifier relatedIdentifierType="arXiv" relationType="IsReviewedBy">arXiv:0706.0001</relatedIdentifier>
+    </relatedIdentifiers>
+    <sizes>
+        <size>3KB</size>
+    </sizes>
+    <formats>
+        <format>application/xml</format>
+    </formats>
+    <version>3.1</version>
+    <rightsList>
+        <rights rightsURI="http://creativecommons.org/publicdomain/zero/1.0/">CC0 1.0 Universal</rights>
+    </rightsList>
+    <descriptions>
+        <description xml:lang="en-us" descriptionType="Abstract">
+            XML example of all DataCite Metadata Schema v3.1 properties.
+        </description>
+    </descriptions>
+    <geoLocations>
+        <geoLocation>
+            <geoLocationPoint>31.233 -67.302</geoLocationPoint>
+            <geoLocationBox>41.090 -71.032  42.893 -68.211</geoLocationBox>
+            <geoLocationPlace>Atlantic Ocean</geoLocationPlace>
+        </geoLocation>
+    </geoLocations>
+</resource>

--- a/test_data/stubdata/input/datacite-example-full-v4.1.xml
+++ b/test_data/stubdata/input/datacite-example-full-v4.1.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4.1/metadata.xsd">
+  <identifier identifierType="DOI">10.5072/example-full</identifier>
+  <creators>
+    <creator>
+      <creatorName nameType="Personal">Miller, Elizabeth</creatorName>
+      <givenName>Elizabeth</givenName>
+      <familyName>Miller</familyName>
+      <nameIdentifier schemeURI="http://orcid.org/" nameIdentifierScheme="ORCID">0000-0001-5000-0007</nameIdentifier>
+      <affiliation>DataCite</affiliation>
+    </creator>
+  </creators>
+  <titles>
+    <title xml:lang="en-US">Full DataCite XML Example</title>
+    <title xml:lang="en-US" titleType="Subtitle">Demonstration of DataCite Properties.</title>
+  </titles>
+  <publisher>DataCite</publisher>
+  <publicationYear>2014</publicationYear>
+  <subjects>
+    <subject xml:lang="en-US" schemeURI="http://dewey.info/" subjectScheme="dewey">000 computer science</subject>
+  </subjects>
+  <contributors>
+    <contributor contributorType="ProjectLeader">
+      <contributorName>Starr, Joan</contributorName>
+      <givenName>Joan</givenName>
+      <familyName>Starr</familyName>
+      <nameIdentifier schemeURI="http://orcid.org/" nameIdentifierScheme="ORCID">0000-0002-7285-027X</nameIdentifier>
+      <affiliation>California Digital Library</affiliation>
+    </contributor>
+  </contributors>
+  <dates>
+    <date dateType="Updated" dateInformation="Updated with 4.1 properties">2017-09-13</date>
+  </dates>
+  <language>en-US</language>
+  <resourceType resourceTypeGeneral="Software">XML</resourceType>
+  <alternateIdentifiers>
+    <alternateIdentifier alternateIdentifierType="URL">https://schema.datacite.org/meta/kernel-4.1/example/datacite-example-full-v4.1.xml</alternateIdentifier>
+  </alternateIdentifiers>
+  <relatedIdentifiers>
+    <relatedIdentifier relatedIdentifierType="URL" relationType="HasMetadata" relatedMetadataScheme="citeproc+json" schemeURI="https://github.com/citation-style-language/schema/raw/master/csl-data.json">https://data.datacite.org/application/citeproc+json/10.5072/example-full</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="arXiv" relationType="IsReviewedBy" resourceTypeGeneral="Text">arXiv:0706.0001</relatedIdentifier>
+  </relatedIdentifiers>
+  <sizes>
+    <size>4 kB</size>
+  </sizes>
+  <formats>
+    <format>application/xml</format>
+  </formats>
+  <version>4.1</version>
+  <rightsList>
+    <rights xml:lang="en-US" rightsURI="http://creativecommons.org/publicdomain/zero/1.0/">CC0 1.0 Universal</rights>
+  </rightsList>
+  <descriptions>
+    <description xml:lang="en-US" descriptionType="Abstract">
+      XML example of all DataCite Metadata Schema v4.1 properties.
+    </description>
+  </descriptions>
+  <geoLocations>
+    <geoLocation>
+      <geoLocationPlace>Atlantic Ocean</geoLocationPlace>
+      <geoLocationPoint>
+        <pointLongitude>-67.302</pointLongitude>
+        <pointLatitude>31.233</pointLatitude>
+      </geoLocationPoint>
+      <geoLocationBox>
+        <westBoundLongitude>-71.032</westBoundLongitude>
+        <eastBoundLongitude>-68.211</eastBoundLongitude>
+        <southBoundLatitude>41.090</southBoundLatitude>
+        <northBoundLatitude>42.893</northBoundLatitude>
+      </geoLocationBox>
+      <geoLocationPolygon>
+        <polygonPoint>
+          <pointLatitude>41.991</pointLatitude>
+          <pointLongitude>-71.032</pointLongitude>
+        </polygonPoint>
+        <polygonPoint>
+          <pointLatitude>42.893</pointLatitude>
+          <pointLongitude>-69.622</pointLongitude>
+        </polygonPoint>
+        <polygonPoint>
+          <pointLatitude>41.991</pointLatitude>
+          <pointLongitude>-68.211</pointLongitude>
+        </polygonPoint>
+        <polygonPoint>
+          <pointLatitude>41.090</pointLatitude>
+          <pointLongitude>-69.622</pointLongitude>
+        </polygonPoint>
+        <polygonPoint>
+          <pointLatitude>41.991</pointLatitude>
+          <pointLongitude>-71.032</pointLongitude>
+        </polygonPoint>
+      </geoLocationPolygon>
+    </geoLocation>
+  </geoLocations>
+  <fundingReferences>
+    <fundingReference>
+      <funderName>National Science Foundation</funderName>
+      <funderIdentifier funderIdentifierType="Crossref Funder ID">https://doi.org/10.13039/100000001</funderIdentifier>
+      <awardNumber>CBET-106</awardNumber>
+      <awardTitle>Full DataCite XML Example</awardTitle>
+    </fundingReference>
+  </fundingReferences>
+</resource>

--- a/test_data/stubdata/input/datacite-example-software-v4.1.xml
+++ b/test_data/stubdata/input/datacite-example-software-v4.1.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4.1/metadata.xsd">
+  <identifier identifierType="DOI">10.5072/example-software-2.0</identifier>
+  <creators>
+    <creator>
+      <creatorName nameType="Personal">Zielinski, AT</creatorName>
+      <nameIdentifier schemeURI="http://orcid.org" nameIdentifierScheme="ORCID">0000-0002-2997-2175</nameIdentifier>
+    </creator>
+    <creator>
+      <creatorName nameType="Personal">Kalberer, M</creatorName>
+    </creator>
+    <creator>
+      <creatorName nameType="Personal">Bortolini, C</creatorName>
+    </creator>
+    <creator>
+      <creatorName nameType="Personal">Giorio, C</creatorName>
+    </creator>
+    <creator>
+      <creatorName nameType="Personal">Fuller, SJ</creatorName>
+    </creator>
+    <creator>
+      <creatorName nameType="Personal">Kourtchev, I</creatorName>
+    </creator>
+    <creator>
+      <creatorName nameType="Personal">Popoola, O</creatorName>
+    </creator>
+  </creators>
+  <titles>
+    <title xml:lang="en">Code supporting "A new processing scheme for ultra-high resolution direct infusion mass spectrometry data"</title>
+  </titles>
+  <publisher>Apollo - University of Cambridge Repository</publisher>
+  <publicationYear>2017</publicationYear>
+  <subjects>
+    <subject>UHRMS</subject>
+    <subject>ESI</subject>
+    <subject>APPI</subject>
+    <subject>Environmental samples</subject>
+    <subject>direct infusion</subject>
+    <subject>Orbitrap</subject>
+  </subjects>
+  <contributors>
+    <contributor contributorType="HostingInstitution">
+      <contributorName nameType="Organizational">Apollo - University of Cambridge Repository</contributorName>
+    </contributor>
+  </contributors>
+  <dates>
+    <date dateType="Issued">2017-05-08</date>
+    <date dateType="Available">2017-05-08</date>
+  </dates>
+  <language>en</language>
+  <resourceType resourceTypeGeneral="Software">Software</resourceType>
+  <relatedIdentifiers>
+    <relatedIdentifier relationType="IsNewVersionOf" relatedIdentifierType="DOI">doi:10.5072/example-software-1.0</relatedIdentifier>
+    <relatedIdentifier relationType="IsVersionOf" relatedIdentifierType="DOI">doi:10.5072/example-software-repository</relatedIdentifier>
+  </relatedIdentifiers>
+  <formats>
+    <format>application/ld+json</format>
+  </formats>
+  <version>2.0</version>
+  <rightsList>
+    <rights rightsURI="https://opensource.org/licenses/GPL-3.0">GNU General Public License version 3</rights>
+  </rightsList>
+  <descriptions>
+    <description xml:lang="en" descriptionType="Abstract">Set of scripts used to process direct infusion mass spectrometry data as described in the associated paper</description>
+    <description xml:lang="en" descriptionType="TechnicalInfo">Scripts written and run using Wolfram Mathematica (confirmed with versions 10.2 to 11.1). Assumes raw data matches format produced by a LTQ Orbitrap Velos mass spectrometer and exported by the proprietary software (Xcalibur) to a comma-separated values (.csv) file. The .csv files are the expected input into the Mathematica scripts.</description>
+  </descriptions>
+</resource>

--- a/test_data/stubdata/parsed/datacite-example-full-v3.1.xml.json
+++ b/test_data/stubdata/parsed/datacite-example-full-v3.1.xml.json
@@ -1,0 +1,23 @@
+{
+    "abstract": "XML example of all DataCite Metadata Schema v3.1 properties.", 
+    "affiliations": [
+        "DataCite <ORCID>0000-0001-5000-0007</ORCID>"
+    ], 
+    "authors": [
+        "Miller, Elizabeth"
+    ], 
+    "bibcode": "", 
+    "doctype": "misc", 
+    "keywords": [
+        "000 computer science"
+    ], 
+    "properties": {
+        "DOI": "10.5072/example-full", 
+        "ELECTR": "http://schema.datacite.org/schema/meta/kernel-3.1/example/datacite-example-full-v3.1.xml"
+    }, 
+    "pubdate": "2014", 
+    "references": [], 
+    "source": "DataCite", 
+    "title": "Demonstration of DataCite Properties.", 
+    "version": "3.1"
+}

--- a/test_data/stubdata/parsed/datacite-example-full-v3.1.xml.json
+++ b/test_data/stubdata/parsed/datacite-example-full-v3.1.xml.json
@@ -7,7 +7,10 @@
         "Miller, Elizabeth"
     ], 
     "bibcode": "", 
-    "doctype": "misc", 
+    "citations": [], 
+    "described_by": [], 
+    "description_of": [], 
+    "doctype": "software", 
     "forked_from": [], 
     "forks": [], 
     "keywords": [

--- a/test_data/stubdata/parsed/datacite-example-full-v3.1.xml.json
+++ b/test_data/stubdata/parsed/datacite-example-full-v3.1.xml.json
@@ -8,6 +8,8 @@
     ], 
     "bibcode": "", 
     "doctype": "misc", 
+    "forked_from": [], 
+    "forks": [], 
     "keywords": [
         "000 computer science"
     ], 
@@ -19,5 +21,7 @@
     "references": [], 
     "source": "DataCite", 
     "title": "Demonstration of DataCite Properties.", 
-    "version": "3.1"
+    "version": "3.1",
+    "version_of": [], 
+    "versions": []
 }

--- a/test_data/stubdata/parsed/datacite-example-full-v4.1.xml.json
+++ b/test_data/stubdata/parsed/datacite-example-full-v4.1.xml.json
@@ -7,7 +7,10 @@
         "Miller, Elizabeth"
     ], 
     "bibcode": "", 
-    "doctype": "misc", 
+    "citations": [], 
+    "described_by": [], 
+    "description_of": [], 
+    "doctype": "software", 
     "forked_from": [], 
     "forks": [], 
     "keywords": [

--- a/test_data/stubdata/parsed/datacite-example-full-v4.1.xml.json
+++ b/test_data/stubdata/parsed/datacite-example-full-v4.1.xml.json
@@ -1,0 +1,23 @@
+{
+    "abstract": "XML example of all DataCite Metadata Schema v4.1 properties.", 
+    "affiliations": [
+        "DataCite <ORCID>0000-0001-5000-0007</ORCID>"
+    ], 
+    "authors": [
+        "Miller, Elizabeth"
+    ], 
+    "bibcode": "", 
+    "doctype": "misc", 
+    "keywords": [
+        "000 computer science"
+    ], 
+    "properties": {
+        "DOI": "10.5072/example-full", 
+        "ELECTR": "https://schema.datacite.org/meta/kernel-4.1/example/datacite-example-full-v4.1.xml"
+    }, 
+    "pubdate": "2014", 
+    "references": [], 
+    "source": "DataCite", 
+    "title": "Demonstration of DataCite Properties.", 
+    "version": "4.1"
+}

--- a/test_data/stubdata/parsed/datacite-example-full-v4.1.xml.json
+++ b/test_data/stubdata/parsed/datacite-example-full-v4.1.xml.json
@@ -8,6 +8,8 @@
     ], 
     "bibcode": "", 
     "doctype": "misc", 
+    "forked_from": [], 
+    "forks": [], 
     "keywords": [
         "000 computer science"
     ], 
@@ -19,5 +21,7 @@
     "references": [], 
     "source": "DataCite", 
     "title": "Demonstration of DataCite Properties.", 
-    "version": "4.1"
+    "version": "4.1",
+    "version_of": [], 
+    "versions": []
 }

--- a/test_data/stubdata/parsed/datacite-example-software-v4.1.xml.json
+++ b/test_data/stubdata/parsed/datacite-example-software-v4.1.xml.json
@@ -20,6 +20,8 @@
     ], 
     "bibcode": "", 
     "doctype": "misc", 
+    "forked_from": [], 
+    "forks": [], 
     "keywords": [
         "UHRMS", 
         "ESI", 
@@ -35,5 +37,9 @@
     "references": [], 
     "source": "Apollo - University of Cambridge Repository", 
     "title": "Code supporting \"A new processing scheme for ultra-high resolution direct infusion mass spectrometry data\"", 
-    "version": "2.0"
+    "version": "2.0",
+    "version_of": [
+        "doi:10.5072/example-software-repository"
+    ], 
+    "versions": []
 }

--- a/test_data/stubdata/parsed/datacite-example-software-v4.1.xml.json
+++ b/test_data/stubdata/parsed/datacite-example-software-v4.1.xml.json
@@ -19,7 +19,10 @@
         "Popoola, O"
     ], 
     "bibcode": "", 
-    "doctype": "misc", 
+    "citations": [], 
+    "described_by": [], 
+    "description_of": [], 
+    "doctype": "software", 
     "forked_from": [], 
     "forks": [], 
     "keywords": [

--- a/test_data/stubdata/parsed/datacite-example-software-v4.1.xml.json
+++ b/test_data/stubdata/parsed/datacite-example-software-v4.1.xml.json
@@ -1,0 +1,39 @@
+{
+    "abstract": "Set of scripts used to process direct infusion mass spectrometry data as described in the associated paper", 
+    "affiliations": [
+        "<ORCID>0000-0002-2997-2175</ORCID>", 
+        "", 
+        "", 
+        "", 
+        "", 
+        "", 
+        ""
+    ], 
+    "authors": [
+        "Zielinski, AT", 
+        "Kalberer, M", 
+        "Bortolini, C", 
+        "Giorio, C", 
+        "Fuller, SJ", 
+        "Kourtchev, I", 
+        "Popoola, O"
+    ], 
+    "bibcode": "", 
+    "doctype": "misc", 
+    "keywords": [
+        "UHRMS", 
+        "ESI", 
+        "APPI", 
+        "Environmental samples", 
+        "direct infusion", 
+        "Orbitrap"
+    ], 
+    "properties": {
+        "DOI": "10.5072/example-software-2.0"
+    }, 
+    "pubdate": "2017-05-08", 
+    "references": [], 
+    "source": "Apollo - University of Cambridge Repository", 
+    "title": "Code supporting \"A new processing scheme for ultra-high resolution direct infusion mass spectrometry data\"", 
+    "version": "2.0"
+}

--- a/test_data/stubdata/parsed/zenodo.org_record_10415_export_dcite3.json
+++ b/test_data/stubdata/parsed/zenodo.org_record_10415_export_dcite3.json
@@ -291,7 +291,11 @@
         "Leitherer, C., Robert, C.,  Drissen, L. 1992, ApJ, 401, 596"
     ], 
     "doctype": "misc",
+    "forked_from": [], 
+    "forks": [], 
     "version": "",
+    "version_of": [], 
+    "versions": [],
     "source": "Zenodo", 
     "title": "Core-collapse Supernova Progenitors in the Era of Untargeted Transient Searches"
 }

--- a/test_data/stubdata/parsed/zenodo.org_record_10415_export_dcite3.json
+++ b/test_data/stubdata/parsed/zenodo.org_record_10415_export_dcite3.json
@@ -7,6 +7,9 @@
         "Sanders, Nathan"
     ], 
     "bibcode": "2014PhDT........11S", 
+    "citations": [], 
+    "described_by": [], 
+    "description_of": [], 
     "keywords": [
         "Astronomy", 
         "Astrophysics", 

--- a/test_data/stubdata/parsed/zenodo.org_record_10415_export_dcite3.json
+++ b/test_data/stubdata/parsed/zenodo.org_record_10415_export_dcite3.json
@@ -290,6 +290,8 @@
         "Leibundgut, B., Kirshner, R., Huchra, J.,  Daugherty, D. 1991, IAU Circ., 5237, 2", 
         "Leitherer, C., Robert, C.,  Drissen, L. 1992, ApJ, 401, 596"
     ], 
+    "doctype": "misc",
+    "version": "",
     "source": "Zenodo", 
     "title": "Core-collapse Supernova Progenitors in the Era of Untargeted Transient Searches"
 }

--- a/test_data/stubdata/parsed/zenodo.org_record_16728_export_dcite3.json
+++ b/test_data/stubdata/parsed/zenodo.org_record_16728_export_dcite3.json
@@ -22,6 +22,8 @@
     }, 
     "pubdate": "1996-06-14", 
     "references": [], 
+    "doctype": "misc",
+    "version": "",
     "source": "Zenodo", 
     "title": "Planetary Atmospheres: Probing Structure through Millimeterwave Observations of Carbon Monoxide"
 }

--- a/test_data/stubdata/parsed/zenodo.org_record_16728_export_dcite3.json
+++ b/test_data/stubdata/parsed/zenodo.org_record_16728_export_dcite3.json
@@ -7,6 +7,9 @@
         "Gurwell, Mark Andrew"
     ], 
     "bibcode": "1996PhDT.........1G", 
+    "citations": [], 
+    "described_by": [], 
+    "description_of": [], 
     "keywords": [
         "TITAN", 
         "MARS", 

--- a/test_data/stubdata/parsed/zenodo.org_record_16728_export_dcite3.json
+++ b/test_data/stubdata/parsed/zenodo.org_record_16728_export_dcite3.json
@@ -23,7 +23,11 @@
     "pubdate": "1996-06-14", 
     "references": [], 
     "doctype": "misc",
+    "forked_from": [], 
+    "forks": [], 
     "version": "",
+    "version_of": [], 
+    "versions": [],
     "source": "Zenodo", 
     "title": "Planetary Atmospheres: Probing Structure through Millimeterwave Observations of Carbon Monoxide"
 }

--- a/test_data/stubdata/parsed/zenodo.org_record_16733_export_dcite3.json
+++ b/test_data/stubdata/parsed/zenodo.org_record_16733_export_dcite3.json
@@ -16,6 +16,8 @@
     }, 
     "pubdate": "2011-03-11", 
     "references": [], 
+    "doctype": "misc",
+    "version": "",
     "source": "Zenodo", 
     "title": "The Formation of Dark Matter Halos and High-Redshift Galaxies"
 }

--- a/test_data/stubdata/parsed/zenodo.org_record_16733_export_dcite3.json
+++ b/test_data/stubdata/parsed/zenodo.org_record_16733_export_dcite3.json
@@ -7,6 +7,9 @@
         "Genel, Shy"
     ], 
     "bibcode": "", 
+    "citations": [], 
+    "described_by": [], 
+    "description_of": [], 
     "keywords": [], 
     "properties": {
         "DOI": "10.5281/zenodo.16733", 

--- a/test_data/stubdata/parsed/zenodo.org_record_16733_export_dcite3.json
+++ b/test_data/stubdata/parsed/zenodo.org_record_16733_export_dcite3.json
@@ -17,7 +17,11 @@
     "pubdate": "2011-03-11", 
     "references": [], 
     "doctype": "misc",
+    "forked_from": [], 
+    "forks": [], 
     "version": "",
+    "version_of": [], 
+    "versions": [],
     "source": "Zenodo", 
     "title": "The Formation of Dark Matter Halos and High-Redshift Galaxies"
 }

--- a/test_data/stubdata/parsed/zenodo.org_record_16738_export_dcite3.json
+++ b/test_data/stubdata/parsed/zenodo.org_record_16738_export_dcite3.json
@@ -16,6 +16,8 @@
     }, 
     "pubdate": "2013-08-10", 
     "references": [], 
+    "doctype": "misc",
+    "version": "",
     "source": "Zenodo", 
     "title": "The Structure and Evolution of Massive Star and Cluster Forming Regions"
 }

--- a/test_data/stubdata/parsed/zenodo.org_record_16738_export_dcite3.json
+++ b/test_data/stubdata/parsed/zenodo.org_record_16738_export_dcite3.json
@@ -7,6 +7,9 @@
         "Battersby, Cara"
     ], 
     "bibcode": "2013PhDT.......193B", 
+    "citations": [], 
+    "described_by": [], 
+    "description_of": [], 
     "keywords": [], 
     "properties": {
         "DOI": "10.5281/zenodo.16738", 

--- a/test_data/stubdata/parsed/zenodo.org_record_16738_export_dcite3.json
+++ b/test_data/stubdata/parsed/zenodo.org_record_16738_export_dcite3.json
@@ -17,7 +17,11 @@
     "pubdate": "2013-08-10", 
     "references": [], 
     "doctype": "misc",
+    "forked_from": [], 
+    "forks": [], 
     "version": "",
+    "version_of": [], 
+    "versions": [],
     "source": "Zenodo", 
     "title": "The Structure and Evolution of Massive Star and Cluster Forming Regions"
 }

--- a/test_data/stubdata/parsed/zenodo.org_record_16803_export_dcite3.json
+++ b/test_data/stubdata/parsed/zenodo.org_record_16803_export_dcite3.json
@@ -20,6 +20,8 @@
     }, 
     "pubdate": "2009-06-30", 
     "references": [], 
+    "doctype": "misc",
+    "version": "",
     "source": "Zenodo", 
     "title": "Simulation and Analysis of Magnetic Reconnection in a Laboratory Plasma Astrophysics Experiment"
 }

--- a/test_data/stubdata/parsed/zenodo.org_record_16803_export_dcite3.json
+++ b/test_data/stubdata/parsed/zenodo.org_record_16803_export_dcite3.json
@@ -7,6 +7,9 @@
         "Murphy, Nicholas"
     ], 
     "bibcode": "2009PhDT........25M", 
+    "citations": [], 
+    "described_by": [], 
+    "description_of": [], 
     "keywords": [
         "Magnetic reconnection", 
         "Plasma physics", 

--- a/test_data/stubdata/parsed/zenodo.org_record_16803_export_dcite3.json
+++ b/test_data/stubdata/parsed/zenodo.org_record_16803_export_dcite3.json
@@ -21,7 +21,11 @@
     "pubdate": "2009-06-30", 
     "references": [], 
     "doctype": "misc",
+    "forked_from": [], 
+    "forks": [], 
     "version": "",
+    "version_of": [], 
+    "versions": [],
     "source": "Zenodo", 
     "title": "Simulation and Analysis of Magnetic Reconnection in a Laboratory Plasma Astrophysics Experiment"
 }

--- a/test_data/stubdata/parsed/zenodo.org_record_16839_export_dcite3.json
+++ b/test_data/stubdata/parsed/zenodo.org_record_16839_export_dcite3.json
@@ -22,7 +22,11 @@
     "pubdate": "2002-05-06", 
     "references": [], 
     "doctype": "misc",
+    "forked_from": [], 
+    "forks": [], 
     "version": "",
+    "version_of": [], 
+    "versions": [],
     "source": "Zenodo", 
     "title": "Spectroscopy:  Instrumentation and Applications to the Galaxy and to the Large Scale Structure of the Universe"
 }

--- a/test_data/stubdata/parsed/zenodo.org_record_16839_export_dcite3.json
+++ b/test_data/stubdata/parsed/zenodo.org_record_16839_export_dcite3.json
@@ -21,6 +21,8 @@
     }, 
     "pubdate": "2002-05-06", 
     "references": [], 
+    "doctype": "misc",
+    "version": "",
     "source": "Zenodo", 
     "title": "Spectroscopy:  Instrumentation and Applications to the Galaxy and to the Large Scale Structure of the Universe"
 }

--- a/test_data/stubdata/parsed/zenodo.org_record_16839_export_dcite3.json
+++ b/test_data/stubdata/parsed/zenodo.org_record_16839_export_dcite3.json
@@ -7,6 +7,9 @@
         "Brown, Warren R."
     ], 
     "bibcode": "", 
+    "citations": [], 
+    "described_by": [], 
+    "description_of": [], 
     "keywords": [
         "spectroscopy", 
         "galaxies", 

--- a/test_data/stubdata/parsed/zenodo.org_record_16861_export_dcite3.json
+++ b/test_data/stubdata/parsed/zenodo.org_record_16861_export_dcite3.json
@@ -22,7 +22,11 @@
     "pubdate": "1975-08-29", 
     "references": [], 
     "doctype": "misc",
+    "forked_from": [], 
+    "forks": [], 
     "version": "",
+    "version_of": [], 
+    "versions": [],
     "source": "Zenodo", 
     "title": "The Use of a Self-Scanning Silicon Photodiode Array for Astronomical Spectroscopy"
 }

--- a/test_data/stubdata/parsed/zenodo.org_record_16861_export_dcite3.json
+++ b/test_data/stubdata/parsed/zenodo.org_record_16861_export_dcite3.json
@@ -21,6 +21,8 @@
     }, 
     "pubdate": "1975-08-29", 
     "references": [], 
+    "doctype": "misc",
+    "version": "",
     "source": "Zenodo", 
     "title": "The Use of a Self-Scanning Silicon Photodiode Array for Astronomical Spectroscopy"
 }

--- a/test_data/stubdata/parsed/zenodo.org_record_16861_export_dcite3.json
+++ b/test_data/stubdata/parsed/zenodo.org_record_16861_export_dcite3.json
@@ -7,6 +7,9 @@
         "Geary, John Charles"
     ], 
     "bibcode": "1975PhDT........53G", 
+    "citations": [], 
+    "described_by": [], 
+    "description_of": [], 
     "keywords": [
         "Astronomy", 
         "Astronomical spectroscopy", 

--- a/test_data/stubdata/parsed/zenodo.org_record_34495_export_dcite3.json
+++ b/test_data/stubdata/parsed/zenodo.org_record_34495_export_dcite3.json
@@ -9,6 +9,9 @@
         "Solano, Enrique"
     ], 
     "bibcode": "", 
+    "citations": [], 
+    "described_by": [], 
+    "description_of": [], 
     "keywords": [
         "Science data management"
     ], 

--- a/test_data/stubdata/parsed/zenodo.org_record_34495_export_dcite3.json
+++ b/test_data/stubdata/parsed/zenodo.org_record_34495_export_dcite3.json
@@ -20,6 +20,8 @@
     }, 
     "pubdate": "2015-12-01", 
     "references": [], 
+    "doctype": "misc",
+    "version": "",
     "source": "Zenodo", 
     "title": "The GTC Public Archive"
 }

--- a/test_data/stubdata/parsed/zenodo.org_record_34495_export_dcite3.json
+++ b/test_data/stubdata/parsed/zenodo.org_record_34495_export_dcite3.json
@@ -21,7 +21,11 @@
     "pubdate": "2015-12-01", 
     "references": [], 
     "doctype": "misc",
+    "forked_from": [], 
+    "forks": [], 
     "version": "",
+    "version_of": [], 
+    "versions": [],
     "source": "Zenodo", 
     "title": "The GTC Public Archive"
 }

--- a/test_data/stubdata/serialized/datacite-example-full-v3.1.xml.tag
+++ b/test_data/stubdata/serialized/datacite-example-full-v3.1.xml.tag
@@ -1,0 +1,9 @@
+%T Demonstration of DataCite Properties.
+%A Miller, Elizabeth
+%F AA(DataCite <ORCID>0000-0001-5000-0007</ORCID>)
+%D 2014/09
+%G DataCite
+%K 000 computer science
+%B XML example of all DataCite Metadata Schema v3.1 properties.
+%I DOI: 10.5072/example-full; ELECTR: http://schema.datacite.org/schema/meta/kernel-3.1/example/datacite-example-full-v3.1.xml
+

--- a/test_data/stubdata/serialized/datacite-example-full-v4.1.xml.tag
+++ b/test_data/stubdata/serialized/datacite-example-full-v4.1.xml.tag
@@ -1,0 +1,9 @@
+%T Demonstration of DataCite Properties.
+%A Miller, Elizabeth
+%F AA(DataCite <ORCID>0000-0001-5000-0007</ORCID>)
+%D 2014/09
+%G DataCite
+%K 000 computer science
+%B XML example of all DataCite Metadata Schema v4.1 properties.
+%I DOI: 10.5072/example-full; ELECTR: https://schema.datacite.org/meta/kernel-4.1/example/datacite-example-full-v4.1.xml
+

--- a/test_data/stubdata/serialized/datacite-example-software-v4.1.xml.tag
+++ b/test_data/stubdata/serialized/datacite-example-software-v4.1.xml.tag
@@ -1,0 +1,9 @@
+%T Code supporting "A new processing scheme for ultra-high resolution direct infusion mass spectrometry data"
+%A Zielinski, AT; Kalberer, M; Bortolini, C; Giorio, C; Fuller, SJ; Kourtchev, I; Popoola, O
+%F AA(<ORCID>0000-0002-2997-2175</ORCID>), AB(), AC(), AD(), AE(), AF(), AG()
+%D 2017/05
+%G Apollo - University of Cambridge Repository
+%K UHRMS, ESI, APPI, Environmental samples, direct infusion, Orbitrap
+%B Set of scripts used to process direct infusion mass spectrometry data as described in the associated paper
+%I DOI: 10.5072/example-software-2.0
+


### PR DESCRIPTION
- Improved setup to grab version from git tag and requirements from file
- Accept datacite schema version 4 too
- Renamed datacite, included version and doctype, added test examples
- Read citations from relatedIdentifiers
- Added versions/forks/citations/described_by/description_of for datacite parsing