### PR TITLE
Fix for issue #25 : Modified classic serializer to deal with dates without month or day

### DIFF
--- a/pyingest/serializers/classic.py
+++ b/pyingest/serializers/classic.py
@@ -25,8 +25,11 @@ def format_affids(affils):
     return formatted
 
 def format_pubdate(date):
-    parsed = dateparser(date)
-    return parsed.strftime("%Y/%m")
+    if len(date) == 4 and (1*date == date):
+        return date+"/00"
+    else:
+        parsed = dateparser(date)
+        return parsed.strftime("%Y/%m")
 
 class Tagged(object):
     

--- a/pyingest/serializers/classic.py
+++ b/pyingest/serializers/classic.py
@@ -25,11 +25,15 @@ def format_affids(affils):
     return formatted
 
 def format_pubdate(date):
-    if len(date) == 4 and (1*date == date):
-        return date+"/00"
-    else:
-        parsed = dateparser(date)
-        return parsed.strftime("%Y/%m")
+    if len(date) == 4:
+        try:
+            int(date)
+        except:
+            pass
+        else:
+            return date+"/00"
+    parsed = dateparser(date)
+    return parsed.strftime("%Y/%m")
 
 class Tagged(object):
     

--- a/pyingest/tests/test_serializers.py
+++ b/pyingest/tests/test_serializers.py
@@ -14,9 +14,7 @@ class TestClassic(unittest.TestCase):
 
     def setUp(self):
         stubdata_dir = os.path.join(os.path.dirname(__file__), '../../test_data/stubdata')
-        print ('lol stubdata_dir:',stubdata_dir)
         self.inputdocs = glob.glob(os.path.join(stubdata_dir, 'parsed/*.json'))
-        print('lol self.inputdocs:',self.inputdocs)
         self.outputdir = os.path.join(stubdata_dir, 'serialized')
 #        sys.stderr.write("test cases are: {}\n".format(self.inputdocs))
 

--- a/test_data/stubdata/serialized/datacite-example-full-v3.1.xml.tag
+++ b/test_data/stubdata/serialized/datacite-example-full-v3.1.xml.tag
@@ -1,7 +1,7 @@
 %T Demonstration of DataCite Properties.
 %A Miller, Elizabeth
 %F AA(DataCite <ORCID>0000-0001-5000-0007</ORCID>)
-%D 2014/09
+%D 2014/00
 %G DataCite
 %K 000 computer science
 %B XML example of all DataCite Metadata Schema v3.1 properties.

--- a/test_data/stubdata/serialized/datacite-example-full-v4.1.xml.tag
+++ b/test_data/stubdata/serialized/datacite-example-full-v4.1.xml.tag
@@ -1,7 +1,7 @@
 %T Demonstration of DataCite Properties.
 %A Miller, Elizabeth
 %F AA(DataCite <ORCID>0000-0001-5000-0007</ORCID>)
-%D 2014/09
+%D 2014/00
 %G DataCite
 %K 000 computer science
 %B XML example of all DataCite Metadata Schema v4.1 properties.


### PR DESCRIPTION
If the date is: (a) four characters long, and (b) an integer, return pubdate as "date/00".