### PR TITLE
adding adsperl/classic name-parsing to arxiv/DI

### DIFF
--- a/pyingest/config/config.py
+++ b/pyingest/config/config.py
@@ -184,4 +184,4 @@ COLLAB_SPLIT = True
 AUTHOR_SEP = ';'
 PRIORITY_LAST = True
 
-CONSTANTS.string_format = u'{last}, {first}, {suffix}'
+CONSTANTS.string_format = u'{last}, {first} "{nickname}", {suffix}'

--- a/pyingest/config/config.py
+++ b/pyingest/config/config.py
@@ -152,3 +152,36 @@ JATS_TAGSET = {'title':JATS_TAGS_MATH + JATS_TAGS_HTML,
             'affiliations':['email','orcid'],
             'keywords':['astrobj']
         }
+
+
+
+
+# NAME-PARSING DEFAULTS: used by parsers/arxiv.py
+
+from nameparser import HumanName
+from nameparser.config import CONSTANTS
+
+# Name overrides from CLASSIC name parser
+
+AUTH_CONFIG = '/proj/ads/abstracts/config/Authors'
+FIRST_NAMES = AUTH_CONFIG + '/first.dat'
+LAST_NAMES = AUTH_CONFIG + '/last.dat'
+PREFIX_NAMES = AUTH_CONFIG + '/prefixes.dat'
+SUFFIX_NAMES = AUTH_CONFIG + '/suffixes.dat'
+
+# Names/titles being added
+
+# To remove *all* of the preset titles:
+CONSTANTS.titles.remove(*CONSTANTS.titles)
+CONSTANTS.suffix_acronyms.remove(*CONSTANTS.suffix_acronyms)
+CONSTANTS.suffix_not_acronyms.remove(*CONSTANTS.suffix_not_acronyms)
+
+# check for these strings to find collaborations
+COLLAB_STRINGS = ['group', 'team', 'collaboration']
+COLLAB_REMOVE_THE = False
+COLLAB_SPLIT = True
+
+AUTHOR_SEP = ';'
+PRIORITY_LAST = True
+
+CONSTANTS.string_format = u'{last}, {first}, {suffix}'

--- a/pyingest/parsers/ads_nameparser.py
+++ b/pyingest/parsers/ads_nameparser.py
@@ -71,9 +71,9 @@ def check_collab(instring,first_names,last_names):
 
 
 def reorder_names(instring,first_names,last_names):
-    a = ads_ex.UNICODE_HANDLER.ent2u(instring)
-    a = ads_ex.UNICODE_HANDLER.remove_control_chars(a)
-    a = ads_ex.RE_INITIAL.sub('. ', a)
+#   a = ads_ex.UNICODE_HANDLER.ent2u(instring)
+#   a = ads_ex.UNICODE_HANDLER.remove_control_chars(a)
+    a = ads_ex.RE_INITIAL.sub('. ', instring)
     a = a.strip().strip(';')
     collab_check = check_collab(a,first_names,last_names)
     if collab_check is not None:
@@ -141,7 +141,8 @@ def reorder_names(instring,first_names,last_names):
     except:
         return "ERROR RETURNING NAME"
     else:
-        return auth_string
+        print "LOLLLL: ",auth_string
+        return ads_ex.UNICODE_HANDLER.ent2u(auth_string).replace('  ',' ')
 
 
 def ads_name_adjust(instring):
@@ -159,14 +160,18 @@ def ads_name_adjust(instring):
         first_names = []
         last_names = []
 
-    instring_clean = named_entities(instring)
-    author_list = instring_clean.split(config.AUTHOR_SEP)
+# ERROR IS HERE: YOU CAN'T SPLIT ON SEMICOLON UNTIL YOU'VE CONVERTED TO UTF8
+#... BUT ONCE YOU DO THAT, YOU FAIL ON THE OUTSTRING JOIN BELOW!
+    author_list = instring.split(config.AUTHOR_SEP)
+    author_list_clean = [named_entities(n) for n in author_list]
+    print "WOOOOO",author_list_clean
 #   lists for pre- and post-nameparser comparison
 
     author_out = []
-    for a in author_list:
+    for a in author_list_clean:
         for name in reorder_names(a,first_names,last_names).split(';'):
             author_out.append(name)
-        outstring = '; '.join(author_out).encode('utf-8').replace(' ,',',').replace('  ',' ')
+#       outstring = '; '.join(author_out).encode('utf-8').replace(' ,',',').replace('  ',' ')
+        outstring = '; '.join(author_out).replace(' ,',',').replace('  ',' ')
     return outstring
 

--- a/pyingest/parsers/ads_nameparser.py
+++ b/pyingest/parsers/ads_nameparser.py
@@ -72,12 +72,15 @@ def check_collab(instring,first_names,last_names):
 
 def reorder_names(instring,first_names,last_names):
     a = ads_ex.RE_INITIAL.sub('. ', instring)
-    a = a.strip().strip(';')
+#   a = a.strip().strip(';')
+    a = a.strip()
     collab_check = check_collab(a,first_names,last_names)
     if collab_check is not None:
         return collab_check
     else:
         author = config.HumanName(a)
+#       print "unprocessed name: ",str(author),str(author.middle)
+        
 
         if (author.middle):
             add_to_first = []
@@ -88,7 +91,7 @@ def reorder_names(instring,first_names,last_names):
 
             try:
                 for subname in parts:
-                    if (len(subname.strip('.').strip('-')) <= 2 and subname.upper() not in last_names) or (subname.upper() in first_names):
+                    if (len(ads_ex.UNICODE_HANDLER.ent2u(subname).strip('.').strip('-')) <= 2 and subname.upper() not in last_names and "'" not in subname) or (subname.upper() in first_names and subname.upper() not in last_names):
                         if llast:
                             add_to_last.reverse()
                             while add_to_last:
@@ -116,13 +119,14 @@ def reorder_names(instring,first_names,last_names):
 
 # YOU NEED TO CHECK THAT NO FIRST NAMES APPEAR IN LAST
         if (author.last):
+#           print "\tmoving any lasts to first: ",str(author.last)
             parts = author.last.split()
             author_last_new = [parts[-1]]
             r_parts = parts[:-1]
             r_parts.reverse()
             try:
                 for subname in r_parts:
-                    if subname.upper() in first_names:
+                    if subname.upper() in first_names and subname.upper() not in last_names:
                         author.first = [author.first, subname]
                     else:
                         author_last_new.append(subname)
@@ -139,7 +143,7 @@ def reorder_names(instring,first_names,last_names):
     except:
         return "ERROR RETURNING NAME"
     else:
-        print "LOLLLL: ",auth_string
+#       print "LOLLLL: ",auth_string
         return ads_ex.UNICODE_HANDLER.ent2u(auth_string).replace('  ',' ')
 
 
@@ -154,6 +158,7 @@ def ads_name_adjust(instring):
             config.CONSTANTS.titles.add(s)
         for s in suffix_names:
             config.CONSTANTS.suffix_acronyms.add(s)
+            config.CONSTANTS.suffix_not_acronyms.add(s)
     except Exception as e:
         first_names = []
         last_names = []
@@ -162,7 +167,7 @@ def ads_name_adjust(instring):
 #... BUT ONCE YOU DO THAT, YOU FAIL ON THE OUTSTRING JOIN BELOW!
     author_list = instring.split(config.AUTHOR_SEP)
     author_list_clean = [named_entities(n) for n in author_list]
-    print "WOOOOO",author_list_clean
+#   print "WOOOOO",author_list_clean
 #   lists for pre- and post-nameparser comparison
 
     author_out = []
@@ -170,6 +175,6 @@ def ads_name_adjust(instring):
         for name in reorder_names(a,first_names,last_names).split(';'):
             author_out.append(name)
 #       outstring = '; '.join(author_out).encode('utf-8').replace(' ,',',').replace('  ',' ')
-        outstring = '; '.join(author_out).replace(' ,',',').replace('  ',' ')
+        outstring = '; '.join(author_out).replace(' ,',',').replace('  ',' ').replace('. -','.-')
     return outstring
 

--- a/pyingest/parsers/ads_nameparser.py
+++ b/pyingest/parsers/ads_nameparser.py
@@ -1,0 +1,172 @@
+import sys
+import re
+from namedentities import named_entities
+
+try:
+    import ads.ADSCachedExports as ads_ex
+except ImportError:
+    sys.path.append('/proj/ads/soft/python/lib/site-packages')
+    try:
+        import ads.ADSCachedExports as ads_ex
+    except ImportError as e:
+        print 'Unable to import ads libraries: {}'.format(e)
+
+
+import pyingest.config.config as config
+from adsputils import u2asc
+
+first_names = []
+last_names = []
+
+
+def read_datfile(filename):
+    output_list = []
+    with open(filename,'rU') as fp:
+        for l in fp.readlines():
+            if l.strip() != '' and l[0] != '#':
+                output_list.append(l.strip())
+    return output_list
+
+
+def init_namelists():
+
+    try:
+        first_names = read_datfile(config.FIRST_NAMES)
+        last_names = read_datfile(config.LAST_NAMES)
+        prefix_names = read_datfile(config.PREFIX_NAMES)
+        suffix_names = read_datfile(config.SUFFIX_NAMES)
+    except Exception as e:
+        raise BaseException(e)
+    return first_names,last_names,prefix_names,suffix_names
+
+
+def check_collab(instring,first_names,last_names):
+    try:
+        for s in config.COLLAB_STRINGS:
+            if s in instring.lower():
+                if config.COLLAB_REMOVE_THE:
+                    outstring = instring.replace(u'The ',u'')
+                else:
+                    outstring = instring
+                # if there's a ',' in the string, prob. incl. the 1st author
+                string_list = outstring.split(',')
+                if len(string_list) == 2:
+                    string_list.reverse()
+                    outstring = u' '.join(string_list).encode('utf-8')
+                if config.COLLAB_SPLIT:
+                    a_list = outstring.split(':')
+                    a_split = []
+                    for a in a_list:
+                        if s in a.lower():
+                            a_split.append(a.strip())
+                        else:
+                            a_split.append(reorder_names(a.strip(),first_names,last_names))
+                    a_list = [a.strip() for a in a_split]
+                    outstring = (config.AUTHOR_SEP+u' ').join(a_list).encode('utf-8')
+                return outstring.strip()
+        return
+    except Exception as e:
+        print ("Error in check_collab: ",e)
+        return
+
+
+def reorder_names(instring,first_names,last_names):
+    a = ads_ex.UNICODE_HANDLER.ent2u(instring)
+    a = ads_ex.UNICODE_HANDLER.remove_control_chars(a)
+    a = ads_ex.RE_INITIAL.sub('. ', a)
+    a = a.strip().strip(';')
+    collab_check = check_collab(a,first_names,last_names)
+    if collab_check is not None:
+        return collab_check
+    else:
+        author = config.HumanName(a)
+
+        if (author.middle):
+            add_to_first = []
+            add_to_last = []
+            llast = False
+
+            parts = author.middle.split()
+
+            try:
+                for subname in parts:
+                    if (len(subname.strip('.').strip('-')) <= 2 and subname.upper() not in last_names) or (subname.upper() in first_names):
+                        if llast:
+                            add_to_last.reverse()
+                            while add_to_last:
+                                add_to_first.append(add_to_last.pop())
+                            llast = False
+                        add_to_first.append(subname)
+                    elif (llast) or (subname.upper() in last_names):
+                        add_to_last.append(subname)
+                        llast = True
+                    else:
+                        if (config.PRIORITY_LAST):
+                            add_to_last.append(subname)
+                            llast = True
+                        else:
+                            add_to_first.append(subname)
+            except Exception as e:
+                print "exception in nameparsing: ",e
+            author.middle = u''
+            for name in add_to_first:
+                author.first = [author.first, name]
+            add_to_last.reverse()
+            for name in add_to_last:
+                author.last = [name, author.last]
+        author.middle = u''            
+
+# YOU NEED TO CHECK THAT NO FIRST NAMES APPEAR IN LAST
+        if (author.last):
+            parts = author.last.split()
+            author_last_new = [parts[-1]]
+            r_parts = parts[:-1]
+            r_parts.reverse()
+            try:
+                for subname in r_parts:
+                    if subname.upper() in first_names:
+                        author.first = [author.first, subname]
+                    else:
+                        author_last_new.append(subname)
+            except Exception as e:
+                print "exception in nameparsing: ",e
+            else:
+                author_last_new.reverse()
+                author.last = author_last_new
+                
+#       if (author.last):
+
+    try:
+        auth_string = str(author)
+    except:
+        return "ERROR RETURNING NAME"
+    else:
+        return auth_string
+
+
+def ads_name_adjust(instring):
+    
+# assumes 'instring' is in standardized name format, with individual authors
+# separated by semicolons
+
+    try:
+        (first_names, last_names, prefix_names, suffix_names) = init_namelists()
+        for s in prefix_names:
+            config.CONSTANTS.titles.add(s)
+        for s in suffix_names:
+            config.CONSTANTS.suffix_acronyms.add(s)
+    except Exception as e:
+        first_names = []
+        last_names = []
+
+    instring_clean = named_entities(instring)
+    author_list = instring_clean.split(config.AUTHOR_SEP)
+#   lists for pre- and post-nameparser comparison
+
+    author_out = []
+    for a in author_list:
+        for name in reorder_names(a,first_names,last_names).split(';'):
+            author_out.append(name)
+        outstring = '; '.join(author_out).encode('utf-8').replace(' ,',',').replace('  ',' ')
+    return outstring
+

--- a/pyingest/parsers/ads_nameparser.py
+++ b/pyingest/parsers/ads_nameparser.py
@@ -71,8 +71,6 @@ def check_collab(instring,first_names,last_names):
 
 
 def reorder_names(instring,first_names,last_names):
-#   a = ads_ex.UNICODE_HANDLER.ent2u(instring)
-#   a = ads_ex.UNICODE_HANDLER.remove_control_chars(a)
     a = ads_ex.RE_INITIAL.sub('. ', instring)
     a = a.strip().strip(';')
     collab_check = check_collab(a,first_names,last_names)

--- a/pyingest/parsers/arxiv.py
+++ b/pyingest/parsers/arxiv.py
@@ -54,7 +54,12 @@ class ArxivParser(DublinCoreParser):
             r['abstract']=r['abstract'][0]
 
         if r['authors']:
-            r['authors'] = ads_nameparser.ads_name_adjust(r['authors'])
+            try:
+                reparsed_name = ads_nameparser.ads_name_adjust(r['authors'])
+            except:
+                pass
+            else:
+                r['authors'] = reparsed_name
 
         if r['bibcode']:
             idarray = r['bibcode'].split(':')

--- a/pyingest/parsers/arxiv.py
+++ b/pyingest/parsers/arxiv.py
@@ -5,6 +5,7 @@
 
 import codecs
 from dubcore import DublinCoreParser
+import ads_nameparser
 from adsputils import u2asc
 from xml.parsers import expat
 
@@ -51,6 +52,9 @@ class ArxivParser(DublinCoreParser):
         if r['abstract']:
             r['comments']=[x.replace('Comment:','').strip() for x in r['abstract'][1:]]
             r['abstract']=r['abstract'][0]
+
+        if r['authors']:
+            r['authors'] = ads_nameparser.ads_name_adjust(r['authors'])
 
         if r['bibcode']:
             idarray = r['bibcode'].split(':')

--- a/pyingest/parsers/arxiv.py
+++ b/pyingest/parsers/arxiv.py
@@ -56,8 +56,8 @@ class ArxivParser(DublinCoreParser):
         if r['authors']:
             try:
                 reparsed_name = ads_nameparser.ads_name_adjust(r['authors'])
-            except:
-                pass
+            except exception as e:
+                print("Error in arxiv name parsing: ",e)
             else:
                 r['authors'] = reparsed_name
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ lxml==4.2.1
 functools32==3.2.3.post2
 jsonschema==2.6.0
 namedentities==1.9.4
+nameparser==1.0.2
 python-dateutil==2.6.0
 six==1.11.0
 xmltodict==0.11.0

--- a/test_data/arxiv.test/tagged/oai_ArXiv.org_1711_04702.tagged
+++ b/test_data/arxiv.test/tagged/oai_ArXiv.org_1711_04702.tagged
@@ -1,7 +1,7 @@
-%R 2017arXiv171104702G
+%R 2017arXiv171104702M
 %T wTO: an R package for computing weighted topological overlap and
   consensus networks with an integrated visualization tool
-%A Gysi, Deisy Morselli; Voigt, Andre; Fragoso, Tiago de Miranda; Almaas, Eivind; Nowick, Katja
+%A Morselli Gysi, Deisy; Voigt, Andre; Fragoso, Tiago de Miranda; Almaas, Eivind; Nowick, Katja
 %D 2017/11
 %J eprint arXiv:1711.04702
 %X 13 pages, 3 Figures


### PR DESCRIPTION
This should eliminate most or all of the incorrect author initials in ArXiv Direct Ingest -- name parsing produces results consistent with classic ingest.

Uses nameparser module.