### PR TITLE
 	modified:   setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,5 +39,5 @@ setup(
     include_package_data=True,
     zip_safe=False,
     platforms='any',
-    install_requires=required,
+    install_requires=required
   )


### PR DESCRIPTION
Fixes problem with python3 pip compatibility: a trailing comma for install_requires was generating an error when installing into python3 environment via pip