### PR TITLE
 	modified:   parsers/iop.py

### DIFF
--- a/pyingest/parsers/iop.py
+++ b/pyingest/parsers/iop.py
@@ -158,13 +158,10 @@ class IOPJATSParser(JATSParser):
         for ecf in entity_fields:
             if ecf in output_metadata.keys():
                 try:
-                    print "lol input field", ecf
-                    print "lol input_text", output_metadata[ecf]
                     conv = EntityConverter()
                     conv.input_text = output_metadata[ecf]
                     conv.convert()
                     output_metadata[ecf] = conv.output_text
-                    print "lol output_text", output_metadata[ecf]
                 except Exception, err:
                     print "problem converting %s for %s: %s" % (ecf, output_metadata['bibcode'], err)
 


### PR DESCRIPTION
Removing debugging print statements, not needed for production, no need to retain for stderr