### PR TITLE
 	modified:   pyingest/parsers/jats.py

### DIFF
--- a/pyingest/parsers/jats.py
+++ b/pyingest/parsers/jats.py
@@ -491,8 +491,11 @@ class JATSParser(BaseBeautifulSoupParser):
         ec_fields = ['authors', 'abstract', 'title']
         econv = EntityConverter()
         for ecf in ec_fields:
-            econv.input_text = output_metadata[ecf]
-            econv.convert()
-            output_metadata[ecf] = econv.output_text
+            try:
+                econv.input_text = output_metadata[ecf]
+                econv.convert()
+                output_metadata[ecf] = econv.output_text
+            except Exception, err:
+                pass
 
         return output_metadata


### PR DESCRIPTION
bug fix for jats input without abstracts (e.g. RNAAS)