### PR TITLE
 	modified:   pyingest/parsers/jats.py

### DIFF
--- a/pyingest/parsers/jats.py
+++ b/pyingest/parsers/jats.py
@@ -535,7 +535,7 @@ class JATSParser(BaseBeautifulSoupParser):
                     else:
                         month = self._detag(d.month, [])
                     if int(month) < 10:
-                        month = "0" + str(month)
+                        month = "0" + str(int(month))
                     else:
                         month = str(month)
                     pubdate = month + pubdate


### PR DESCRIPTION
Minor change to jats.py to deal with cases where a publisher has a leading zero in the month field for pubdate.