### PR TITLE
 	modified:   pyingest/parsers/jats.py

### DIFF
--- a/pyingest/parsers/jats.py
+++ b/pyingest/parsers/jats.py
@@ -542,7 +542,7 @@ class JATSParser(BaseBeautifulSoupParser):
             except Exception as errrr:
                 pass
             else:
-                if a == 'print' or b == 'ppub':
+                if a == 'print' or b == 'ppub' or b == 'cover':
                     base_metadata['pubdate'] = pubdate
                 elif a == 'electronic' or b == 'epub':
                     try:


### PR DESCRIPTION
Fix for jats.py to handle MNRAS pub-type (='cover' is what we use for pubdate)