### PR TITLE
 	modified:   requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ feedparser==6.0.8
 future==0.18.2
 habanero==0.7.4
 jsonschema==3.1.1
-lxml==4.6.5
+lxml==4.7.1
 namedentities==1.9.4
 nameparser==1.0.6
 pymarc==3.2.0


### PR DESCRIPTION
For classic serialization: Bumping lxml from 4.6.5 to 4.7.1 to match ADSIngestParser.